### PR TITLE
Allow extension of barcode types (without validation)

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -511,7 +511,7 @@ class Item(WebsiteGenerator):
 		from stdnum import ean
 		if len(self.barcodes) > 0:
 			for item_barcode in self.barcodes:
-				options = frappe.get_meta("Item Barcode").get_options("barcode_type").split()
+				options = frappe.get_meta("Item Barcode").get_options("barcode_type").split('\n')
 				if item_barcode.barcode:
 					duplicate = frappe.db.sql(
 						"""select parent from `tabItem Barcode` where barcode = %s and parent != %s""", (item_barcode.barcode, self.name))
@@ -520,7 +520,7 @@ class Item(WebsiteGenerator):
 							item_barcode.barcode, duplicate[0][0]))
 
 					item_barcode.barcode_type = "" if item_barcode.barcode_type not in options else item_barcode.barcode_type
-					if item_barcode.barcode_type:
+					if item_barcode.barcode_type and item_barcode.barcode_type.upper() in ('EAN', 'UPC-A', 'EAN-13', 'EAN-8'):
 						if not ean.is_valid(item_barcode.barcode):
 							frappe.throw(_("Barcode {0} is not a valid {1} code").format(
 								item_barcode.barcode, item_barcode.barcode_type))


### PR DESCRIPTION
Currently, it is difficult to add new custom barcode types for two reasons, both of which relate to validate_barcode in item.py:
- There is a bug where barcode types with a space in, such as Code 128, are split in two (so barcode_type is checked against 'Code' and '128' rather than 'Code 128'). This is fixed by splitting the Options field against a newline, instead of spaces.
- All barcodes are validated against the stdnum.ean library. This only handles EAN-8, EAN-13 and UPC-12 barcodes and any other barcode will fail. Barcodes with no type will continue to not be checked. Barcodes with the default barcode_types of EAN, UPC will continue to be checked. The non-default barcode_types of EAN-13 and EAN-8 will also be checked. The barcode_type is cast to upper case before this check is made so ean, upc, ean-13 and ean-8 will also be validated.

This allows people to add their own barcode types, such as Code 128 and QR codes. Users can add custom validation of these barcodes using the usual hooks, but they cannot remove the standard validation.

